### PR TITLE
Keep ViraDropdown open during multi-select

### DIFF
--- a/packages/vira-book/src/element-book/entries/vira-dropdown.element.book.ts
+++ b/packages/vira-book/src/element-book/entries/vira-dropdown.element.book.ts
@@ -236,9 +236,20 @@ export const viraDropdownPage = defineBookPage({
                     return html`
                         <${ViraDropdown.assign(finalInputs)}
                             ${listen(ViraDropdown.events.selectedChange, (event) => {
-                                updateState({
-                                    selected: event.detail,
+                                if (!finalInputs.isMultiSelect) {
+                                    updateState({selected: event.detail});
+                                    return;
+                                }
+
+                                const selected = new Set(state.selected);
+                                event.detail.forEach((value) => {
+                                    if (selected.has(value)) {
+                                        selected.delete(value);
+                                    } else {
+                                        selected.add(value);
+                                    }
                                 });
+                                updateState({selected: [...selected]});
                             })}
                         ></${ViraDropdown}>
                     `;

--- a/packages/vira/src/elements/vira-dropdown.element.ts
+++ b/packages/vira/src/elements/vira-dropdown.element.ts
@@ -224,6 +224,7 @@ export const ViraDropdown = defineViraElement<
         const triggerTemplate = html`
             <${ViraPopUpTrigger.assign({
                 ...inputs,
+                keepOpenAfterInteraction: inputs.isMultiSelect,
                 focusOnClose: true,
                 popUpOffset: {
                     vertical: -1,


### PR DESCRIPTION
## What

`ViraDropdown` now derives the pop-up's `keepOpenAfterInteraction` from `isMultiSelect`. Multi-select dropdowns stay open and preserve scroll position across selections, instead of closing and resetting scroll on every click.

```ts
<${ViraPopUpTrigger.assign({
    ...inputs,
    keepOpenAfterInteraction: inputs.isMultiSelect,
    ...
})}
```

## Why

The reported UX bug: with a long multi-select list, every click closed the dropdown and reset its scroll, forcing the user to reopen and re-scroll for each selection.

`ViraPopUpTrigger` already supports `keepOpenAfterInteraction`, but `ViraDropdown` never set it. Rather than expose a separate opt-in input (which would require consumers to pass both `isMultiSelect: true` and `keepOpenAfterInteraction: true`), we derive it: a multi-select that closes on every click is the bug, not a feature. This fixes it for all multi-select consumers with no API surface added.

## Behavior

- `isMultiSelect: true` → menu stays open across clicks, scroll preserved, `selectedChange` fires per click (single clicked value, as before — consumers merge).
- Single-select (default) → unchanged: closes on selection.

## Book

Updated the `vira-dropdown` book example to toggle/accumulate selections when multi-select, so the stay-open behavior is actually demonstrable (the old handler overwrote `selected` with the single clicked value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)