### PR TITLE
Catch showPicker NotAllowedError in vira-select

### DIFF
--- a/packages/vira/src/elements/vira-select.element.test.ts
+++ b/packages/vira/src/elements/vira-select.element.test.ts
@@ -1,0 +1,58 @@
+import {assert, assertWrap} from '@augment-vir/assert';
+import {describe, it, testWeb} from '@augment-vir/test';
+import {waitForAnimationFrame} from '@augment-vir/web';
+import {html} from 'element-vir';
+import {type ViraSelectOption} from '../util/vira-select-option.js';
+import {ViraSelect} from './vira-select.element.js';
+
+const mockOptions: ReadonlyArray<Readonly<ViraSelectOption>> = [
+    {
+        value: '0',
+        label: 'Option A',
+    },
+    {
+        value: '1',
+        label: 'Option B',
+    },
+];
+
+describe(ViraSelect.tagName, () => {
+    it('does not surface showPicker errors when clicked without user activation', async () => {
+        const fixture = await testWeb.render(html`
+            <div>
+                <${ViraSelect.assign({
+                    options: mockOptions,
+                    value: undefined,
+                })}></${ViraSelect}>
+            </div>
+        `);
+        const instance = assertWrap.instanceOf(
+            fixture.querySelector(ViraSelect.tagName),
+            ViraSelect,
+        );
+        await waitForAnimationFrame();
+
+        const showPickerErrors: string[] = [];
+        function trackError(event: ErrorEvent) {
+            if (event.message.includes('showPicker')) {
+                showPickerErrors.push(event.message);
+            }
+        }
+        window.addEventListener('error', trackError);
+
+        instance.dispatchEvent(
+            new MouseEvent('mousedown', {
+                bubbles: true,
+            }),
+        );
+        instance.dispatchEvent(
+            new MouseEvent('click', {
+                bubbles: true,
+            }),
+        );
+        await waitForAnimationFrame(5);
+
+        window.removeEventListener('error', trackError);
+        assert.isEmpty(showPickerErrors);
+    });
+});

--- a/packages/vira/src/elements/vira-select.element.ts
+++ b/packages/vira/src/elements/vira-select.element.ts
@@ -275,7 +275,14 @@ export const ViraSelect = defineViraElement<
                 /** `showPicker` is not in Safari. */
                 // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
                 if (selectElement.showPicker) {
-                    selectElement.showPicker();
+                    try {
+                        selectElement.showPicker();
+                    } catch {
+                        /**
+                         * Chromium throws `NotAllowedError` when `showPicker` runs without
+                         * transient user activation; the picker just won't open.
+                         */
+                    }
                 }
             }),
             listenTo(host, 'click', (event) => {
@@ -290,7 +297,14 @@ export const ViraSelect = defineViraElement<
                 /** `showPicker` is not in Safari. */
                 // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
                 if (selectElement.showPicker) {
-                    selectElement.showPicker();
+                    try {
+                        selectElement.showPicker();
+                    } catch {
+                        /**
+                         * Chromium throws `NotAllowedError` when `showPicker` runs without
+                         * transient user activation; the picker just won't open.
+                         */
+                    }
                 }
             }),
         ];


### PR DESCRIPTION
`ViraSelect` calls `select.showPicker()` from its host `mousedown`/`click` handlers to open the dropdown when a click lands outside the native `<select>`. Chromium throws `NotAllowedError` when `showPicker()` runs without transient user activation (e.g. a synthetic/non-trusted click), and the uncaught exception surfaces as a global error (observed flooding production error reporting).

Wrap the call in try/catch — when there's no activation the picker simply won't open, which is harmless. Added a regression test that dispatches a synthetic click and asserts no `showPicker` error escapes to the global handler (it fails without this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)